### PR TITLE
fix: Change 'ANLEITUNGEN' to 'LEITFÄDEN' in German resources

### DIFF
--- a/src/BfmeFoundationProject_AllInOneLauncher/Resources/Dictionary/LanguageResources.de.xaml
+++ b/src/BfmeFoundationProject_AllInOneLauncher/Resources/Dictionary/LanguageResources.de.xaml
@@ -25,7 +25,7 @@
     <!--=====================  MainWindow  =====================-->
     <system:String x:Key="MainWindowSingleplayerTab">EINZELSPIELER</system:String>
     <system:String x:Key="MainWindowMultiplayerTab">MEHRSPIELER</system:String>
-    <system:String x:Key="MainWindowGuidesTab">ANLEITUNGEN</system:String>
+    <system:String x:Key="MainWindowGuidesTab">LEITFÄDEN</system:String>
     <system:String x:Key="MainWindowAboutTab">ÜBER</system:String>
 
 


### PR DESCRIPTION
Adresses the request from #15 